### PR TITLE
Add Option2 to use cases

### DIFF
--- a/Covid19.Recovery.Registry.Option2.md
+++ b/Covid19.Recovery.Registry.Option2.md
@@ -1,0 +1,17 @@
+# Covid-19 Recovery Registry - Option 2
+
+Survivors of the virus can have a digitally signed Tag attached to their Ravencoin address.
+Cost $0.002 or 0.1 RVN.
+
+1.	Consumers signs up at web interface
+2.	Input needed information
+3.	Upload scan of test
+4.	Chooses whether to encrypt content or not
+5.	Chooses whether to offer their services to local community.  Adds needed information for this.  (Secondary function)
+6.	Consumer adds Ravencoin address or one is created at mangofarmsassets.com to hold asset
+7.	Cost in RVN is $0.002 to tag their address with #COVID19_ANTIBODIES [1]
+8.	Tag is attached to address from step 6 - Timestamping is automatic on-chain
+9.	A persistent copy of the consumers testing data can be produced at any time and remains under the control of the test recipient 
+
+
+[1] Consumer is paying for a tag. 0.1 RVN to pay for the asset issuance. Cost could be subsidized by the website.  Importantly, only the qualifier (owner of #COVID19_ANTIBODIES) would be able to assign the tag.  Unlike a token, a tag cannot be sent to another Ravencoin address.


### PR DESCRIPTION
This option prevents sending of unique token to another, and requires the qualifier (owner of the tag) to be the only signer.  This allows, optionally, the test to be verified before tag issuance.  Different tags could be assigned depending on the type of test, or on the level of verification of the test/doctor.